### PR TITLE
[#5] update invoke to include ordered available reference list for dynamic lookup

### DIFF
--- a/src/main/kotlin/com/empowerops/babel/BabelCompilationResult.kt
+++ b/src/main/kotlin/com/empowerops/babel/BabelCompilationResult.kt
@@ -30,7 +30,7 @@ data class BabelExpression(
     }
 
     @Throws(RuntimeBabelException::class)
-    fun evaluate(globalVars: @Ordered Map<String, Double>): Double {
+    fun evaluate(globalVars: Map<String, Double>, references: @Ordered List<String>): Double {
 
         require(globalVars.isEmpty() || globalVars.javaClass != HashMap::class.java) {
             "babel requires ordered global variables. " +
@@ -44,7 +44,7 @@ data class BabelExpression(
 
         Log.fine { "babel('$expressionLiteral').evaluate('${globalVars.toMap()}')" }
 
-        return runtime.invoke(globalVars)
+        return runtime.invoke(globalVars, references)
     }
 
     companion object {

--- a/src/main/kotlin/com/empowerops/babel/Exceptions.kt
+++ b/src/main/kotlin/com/empowerops/babel/Exceptions.kt
@@ -39,7 +39,8 @@ data class RuntimeProblemSource(
         val summary: String,
         val problemValueDescription: String,
         val heap: ImmutableMap<String, Double>,
-        val globals: @Ordered Map<String, Double>
+        val globals: Map<String, Double>,
+        val references: @Ordered List<String>
 )
 
 class RuntimeBabelException(
@@ -54,6 +55,7 @@ internal fun RuntimeProblemSource.makeExceptionMessage(): String {
       |$markedUpSource
       |local-variables$heap
       |parameters$globals
+      |available reference$references
       """.trimMargin()
 }
 internal fun ExpressionProblem.makeStaticMessage(): String {

--- a/src/main/kotlin/com/empowerops/babel/rewriters.kt
+++ b/src/main/kotlin/com/empowerops/babel/rewriters.kt
@@ -401,7 +401,7 @@ class StaticEvaluatorRewritingWalker(val sourceText: String) : BabelParserBaseLi
                 runtime = compiler.instructions.configuration
         )
 
-        val result = expr.evaluate(emptyMap())
+        val result = expr.evaluate(emptyMap(), emptyList())
 
         val originalText = ctx.text
         val (startToken, stopToken) = ctx.start to ctx.stop

--- a/src/test/kotlin/com/empowerops/babel/BabelExpressionFixture.kt
+++ b/src/test/kotlin/com/empowerops/babel/BabelExpressionFixture.kt
@@ -214,8 +214,8 @@ class BabelExpressionFixture {
 
         //act
         val compiledExpression = compiler.compile(expr).successOrThrow()
-        val firstResult = compiledExpression.evaluate(inputs)
-        val secondResult = compiledExpression.evaluate(inputs)
+        val firstResult = compiledExpression.evaluate(inputs, inputs.keys.toList())
+        val secondResult = compiledExpression.evaluate(inputs, inputs.keys.toList())
 
         //assert
         assertThat(firstResult).isEqualTo(expectedResult)


### PR DESCRIPTION
This is a PR for #5 

- add the list of available reference when do evaluation, now it will check the ordered list for the dynamic reference.
- update the tests 